### PR TITLE
Adjust how we compute the default tile path prefix

### DIFF
--- a/lib/controllers/tile-json.js
+++ b/lib/controllers/tile-json.js
@@ -4,7 +4,7 @@ var settings = require('../settings');
 
 function pathPrefix(req) {
   if (!settings.prefix) {
-    return 'https://' + req.headers.host + req.path;
+    return 'https://' + req.headers.host + '/' + req.params.surveyId;
   }
 
   return settings.prefix + '/' + req.params.surveyId;


### PR DESCRIPTION
In the absence of a configured tile URL prefix, we had been using the host and the tile.json path, both from the tile.json request object. That's problematic, though. We could probably clip the `/tile.json` from the end of the path, but at that point we're just creating a path relative to the tile server. That means we know exactly the appropriate URL structure.

We still read the host from the request, but now we use the tile server's URL prefix as the default path prefix.

/cc @hampelm 
