### PR TITLE
Add expiration to the survey stats cache

### DIFF
--- a/lib/survey-stats.js
+++ b/lib/survey-stats.js
@@ -1,10 +1,15 @@
 'use strict';
 
 var __ = require('lodash');
+var lru = require('lru-cache');
 
 var Response = require('./models/Response');
 
-var statsBySurvey = {};
+// Set up LRU cache
+var cache = lru({
+  max: 100,
+  maxAge: 1000 * 60 * 60 // 1 hour
+});
 
 function getStatsFromDB(surveyId, done) {
   var stats = {
@@ -113,7 +118,7 @@ function getStatsFromDB(surveyId, done) {
 
 
 exports.get = function getStats(surveyId, done) {
-  var stats = statsBySurvey[surveyId];
+  var stats = cache.get(surveyId);
   if (stats !== undefined) {
     done(null, stats);
     return;
@@ -124,7 +129,7 @@ exports.get = function getStats(surveyId, done) {
       console.log(error);
       done(error);
     }
-    statsBySurvey[surveyId] = stats;
+    cache.set(surveyId, stats);
     done(null, stats);
   });
 }


### PR DESCRIPTION
Use an LRU cache with a capped size (not a big issue right now) and an expiration.

/cc @hampelm 
