### PR TITLE
Add a namespace prefix to the cached tile path

### DIFF
--- a/lib/s3-cache.js
+++ b/lib/s3-cache.js
@@ -6,6 +6,7 @@ var projector = require("nodetiles-core").projector;
 
 var metrics = require('./metrics/cache');
 var Response = require('./models/Response');
+var settings = require('./settings');
 
 var S3_CUSTOM_CACHE_HEADER = 'x-amz-meta-count';
 
@@ -66,9 +67,12 @@ module.exports = function setup(options) {
     .end();
   }
 
-  function makeTileName(req) {
-    return req.originalUrl;
-  }
+  var makeTileName = (function () {
+    var prefix = '/' + settings.name;
+    return function makeTileName(req) {
+      return prefix + req.originalUrl;
+    };
+  }());
 
   function handleRender(req, res, next) {
     // We'll only apply this ETag caching logic if res.send gets used. If we
@@ -79,7 +83,7 @@ module.exports = function setup(options) {
 
       // Cache the file using S3
       if(s3client) {
-        var name = req.originalUrl;
+        var name = makeTileName(req);
         var headers = {
           'Content-Length': body.length,
           'Content-Type': 'image/png'


### PR DESCRIPTION
We can use the same S3 bucket without worrying about collisions. If development/beta systems create different tiles (or even bad tiles), they won't interfere with production. We can also clear out the cache for a development system much more easily without impacting production performance.

/cc @hampelm 
