### PR TITLE
Cache UTFGrid responses on S3

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -61,9 +61,9 @@ exports.setup = function setup(app) {
   app.get('/:surveyId/filter/:key/:val/tile.json', tileJson.getFilteredKeyValue);
 
   // Serve the UTF grids
-  app.get('/:surveyId/utfgrids/:zoom/:x/:y.:format', parseTileName, tiles.renderGrids);
+  app.get('/:surveyId/utfgrids/:zoom/:x/:y.:format', parseTileName, useS3Cache, tiles.renderGrids);
 
   // Serve the UTF grids for a filter
-  app.get('/:surveyId/filter/:key/:val/utfgrids/:zoom/:x/:y.:format', parseTileName, tiles.renderGrids);
-  app.get('/:surveyId/filter/:key/utfgrids/:zoom/:x/:y.:format', parseTileName, tiles.renderGrids);
+  app.get('/:surveyId/filter/:key/:val/utfgrids/:zoom/:x/:y.:format', parseTileName, useS3Cache, tiles.renderGrids);
+  app.get('/:surveyId/filter/:key/utfgrids/:zoom/:x/:y.:format', parseTileName, useS3Cache, tiles.renderGrids);
 };


### PR DESCRIPTION
Tested on Heroku. PNGs and UTFGrid JSONP are both cached on S3 and served as redirects from the tile server.

/cc @hampelm 
