### PR TITLE
Add default NAME to settings and add NAME to the sample setenv

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -15,6 +15,6 @@ settings.noAnswer = 'no response';
 
 // Monitoring/instrumentation
 settings.newRelicKey = process.env.NEW_RELIC_LICENSE_KEY;
-settings.name = process.env.NAME;
+settings.name = process.env.NAME || 'default-tileserver';
 
 settings.expressLogger = process.env.EXPRESS_LOGGER || 'default';

--- a/setenv_local.sh.sample
+++ b/setenv_local.sh.sample
@@ -3,6 +3,7 @@ export SSL_KEY="/Users/coolguy/.ssh/localdata-key.pem"
 export SSL_CERT="/Users/coolguy/.ssh/localdata-cert.pem"
 export PREFIX="//localhost:3443/tiles"
 
+export NAME="my-tileserver"
 export S3_KEY="foo"
 export S3_SECRET="bar"
 export S3_BUCKET="baz";


### PR DESCRIPTION
Otherwise we get undefined subdirectories in the cache, eg `'https://example.s3.amazonaws.com/undefined/[...]/tiles/15/5242/12665.png'`
