### PR TITLE
Use the correct Content-Type for storing UTFGrids in s3

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -43,10 +43,6 @@ function parseTileName(req, res, next) {
 
   res.locals.tile = tile;
 
-  if(req.params.format === 'json') {
-    res.locals.contentType = 'application/json';
-  }
-
   next();
 }
 

--- a/lib/s3-cache.js
+++ b/lib/s3-cache.js
@@ -86,7 +86,7 @@ module.exports = function setup(options) {
         var name = makeTileName(req);
         var headers = {
           'Content-Length': body.length,
-          'Content-Type': res.locals.contentType || 'image/png'
+          'Content-Type': res.get('Content-Type')
         };
         headers[S3_CUSTOM_CACHE_HEADER] = res.getHeader(S3_CUSTOM_CACHE_HEADER);
         var buffer = new Buffer(body);


### PR DESCRIPTION
My local dashboard doesn't like it when tilejson is served as image/png by s3. This stores the grids with the correct Content-Type. 
