### PR TITLE
Fix the cache validation queries

### DIFF
--- a/lib/etag-cache.js
+++ b/lib/etag-cache.js
@@ -48,14 +48,29 @@ module.exports = function setup() {
   // of the fact that a MongoDB was the underlying resource.
   function hasNewResponses(survey, tile, timestamp, done) {
     var bounds = tileToBounds(tile);
+    var west = bounds[0][0];
+    var south = bounds[0][1];
+    var east = bounds[1][0];
+    var north = bounds[1][1];
+
+    var boundingCoordinates = [ [ [west, south], [west, north], [east, north], [east, south], [west, south] ] ];
+
     var query = {
-      survey: survey
+      'properties.survey': survey
     };
-    query['geo_info.centroid'] = { $within: { $box: bounds } };
-    query.created = { $gt: new Date(timestamp) };
+    query.indexedGeometry = {
+      $geoIntersects: {
+        $geometry: {
+          type: 'Polygon',
+          coordinates: boundingCoordinates
+        }
+      }
+    };
+    
+    query['properties.entries.created'] = { $gt: new Date(timestamp) };
 
     // See if there have been new responses since the timestamp.
-    Response.find(query).limit(1).exec(function (error, docs) {
+    Response.find(query).limit(1).lean().exec(function (error, docs) {
       if (error) {
         return done(error);
       }

--- a/lib/s3-cache.js
+++ b/lib/s3-cache.js
@@ -30,11 +30,25 @@ module.exports = function setup(options) {
 
   function setupQuery(survey, tile) {
     var bounds = tileToBounds(tile);
+    var west = bounds[0][0];
+    var south = bounds[0][1];
+    var east = bounds[1][0];
+    var north = bounds[1][1];
+
+    var boundingCoordinates = [ [ [west, south], [west, north], [east, north], [east, south], [west, south] ] ];
 
     var query = {
-      survey: survey
+      'properties.survey': survey
     };
-    query['geo_info.centroid'] = { $within: { $box: bounds } };
+    query.indexedGeometry = {
+      $geoIntersects: {
+        $geometry: {
+          type: 'Polygon',
+          coordinates: boundingCoordinates
+        }
+      }
+    };
+    
     return query;
   }
 


### PR DESCRIPTION
The ETag and S3 cache pieces were still using queries based on the old Response structure.

/cc @hampelm 
