### PR TITLE
Allow disabling of cache through an env variable

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -12,7 +12,13 @@ var tileJson = require('./controllers/tile-json');
 var useS3Cache;
 var s3client;
 
-if (settings.s3Key !== undefined) {
+function noOp(req, res, next) {
+  next();
+}
+
+if (settings.nocache || !settings.s3Key) {
+  useS3Cache = noOp;
+} else {
   console.log('Using S3 to cache generated tiles. Bucket: ' + settings.s3Bucket);
   useS3Cache = s3Cache({
     s3client: knox.createClient({
@@ -21,10 +27,10 @@ if (settings.s3Key !== undefined) {
       bucket: settings.s3Bucket
     })
   });
-} else {
-  useS3Cache = function (req, res, next) {
-    next();
-  };
+}
+
+if (settings.nocache) {
+  useEtagCache = noOp;
 }
 
 // Parse the tilename parameters from the URL and store as a res.locals.tile

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -13,6 +13,9 @@ settings.prefix = process.env.PREFIX;
 
 settings.noAnswer = 'no response';
 
+// Allow us to disable the caching components with an environment variable
+settings.nocache = process.env.NOCACHE;
+
 // Monitoring/instrumentation
 settings.newRelicKey = process.env.NEW_RELIC_LICENSE_KEY;
 settings.name = process.env.NAME || 'default-tileserver';

--- a/sample.env
+++ b/sample.env
@@ -10,7 +10,11 @@ PREFIX="//localhost:4334"
 # S3 parameters, if you want to cache rendered tiles on S3
 S3_KEY="foo"
 S3_SECRET="bar"
-S3_BUCKET="baz";
+S3_BUCKET="baz"
+
+# You can disable caching by setting NOCACHE to 1. Reenable by unsetting
+# NOCACHE.
+#NOCACHE=1
 
 # New Relic parameters, if you want to use New Relic instrumentation
 NEW_RELIC_LICENSE_KEY=foobar


### PR DESCRIPTION
Unsetting the S3 key config is more cumbersome, and we might want to have S3 credentials on the service for one-off dynos or other needs (like a cache clearing maintenance script).

/cc @hampelm 
