### PR TITLE
Pass errors through to the stream

### DIFF
--- a/lib/controllers/tiles.js
+++ b/lib/controllers/tiles.js
@@ -58,7 +58,12 @@ function createRenderStream(map, tile) {
     width: 256,
     height: 256,
     zoom: tile[0],
-    callback: function(err, canvas) {
+    callback: function (error, canvas) {
+      if (error) {
+        passThrough.emit('error', error);
+        return;
+      }
+
       var stream = canvas.createPNGStream();
 
       // Stop the timer when the stream ends.


### PR DESCRIPTION
Handle the error case in the `map.render` callback instead of trying to continue on, since `canvas` will not be defined.

This comes up when we have invalid geometries in the MongoDB query (#101).

/cc @hampelm 
