### PR TITLE
Handle errors from getCount or getS3Header

### DIFF
--- a/lib/s3-cache.js
+++ b/lib/s3-cache.js
@@ -153,12 +153,30 @@ module.exports = function setup(options) {
     var tile = res.locals.tile;
     var survey = req.params.surveyId;
 
+    function handleError(error) {
+      if (!error) {
+        return false;
+      }
+      console.log('Error validating cache.');
+      console.log(error);
+      console.log('MISS: unable to validate');
+      stopMetric.miss();
+
+      // We need to render a tile.
+      handleRender(req, res, next);
+      return true;
+    }
+
     async.parallel([
       // Get the count
       __.bind(getCount, this, survey, tile),
       // Check if the key is in S3
       __.bind(getS3Header, this, name)
     ], function (error, values) {
+      if (handleError(error)) {
+        return;
+      }
+
       var trueCount = values[0];
       var s3res = values[1];
       var s3Count;
@@ -166,13 +184,8 @@ module.exports = function setup(options) {
       res.setHeader(S3_CUSTOM_CACHE_HEADER, trueCount);
 
       function handleValidation(error, hasNew) {
-        if (error) {
-          console.log('Error validating cache.');
-          console.log('MISS: unable to validate');
-          stopMetric.miss();
-
-          // We need to render a tile.
-          return handleRender(req, res, next);
+        if (handleError(error)) {
+          return;
         }
 
         if (hasNew) {


### PR DESCRIPTION
We have seen an error there in the field, but it went unlogged. Since we didn't fail gracefully, the subsequent code crashed dereferencing `undefined`.

/cc @hampelm 
