### PR TITLE
Limit the number of features drawn

### DIFF
--- a/lib/ds-responses.js
+++ b/lib/ds-responses.js
@@ -10,9 +10,7 @@ var metrics = require('./metrics/pipeline');
 var Response = require('./models/Response');
 var settings = require('./settings');
 
-// Limit the maximum amount of data we'll process, so we have a rough bound on
-// memory usage.
-var QUERY_LIMIT = 20000;
+var maxResponseCount = settings.maxResponseCount;
 
 var NOANSWER = settings.noAnswer;
 var ANSWER = settings.unstructuredAnswer;
@@ -172,8 +170,6 @@ exports.create = function create(options) {
       }
     };
 
-    var limit = QUERY_LIMIT;
-
     var dbTimer = metrics.dbTimer();
     var procTimer = metrics.processingTimer();
 
@@ -197,7 +193,7 @@ exports.create = function create(options) {
     var docStream = Response.find(query)
     .select(select)
     .lean()
-    .limit(limit)
+    .limit(maxResponseCount)
     .stream()
     .on('error', function (error) {
       finish(error);

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -22,3 +22,10 @@ settings.newRelicKey = process.env.NEW_RELIC_LICENSE_KEY;
 settings.name = process.env.NAME || 'default-tileserver';
 
 settings.expressLogger = process.env.EXPRESS_LOGGER || 'default';
+
+// Limit the maximum amount of data we'll process, so we have a rough bound on
+// memory usage.
+settings.maxResponseCount = parseInt(process.env.MAX_COUNT, 10);
+if (isNaN(settings.maxResponseCount)) {
+  settings.maxResponseCount = 20000;
+}

--- a/sample.env
+++ b/sample.env
@@ -16,6 +16,9 @@ S3_BUCKET="baz"
 # NOCACHE.
 #NOCACHE=1
 
+# Configure the maximum number of responses rendered per tile. The default is 20,000.
+#MAX_COUNT=18000
+
 # New Relic parameters, if you want to use New Relic instrumentation
 NEW_RELIC_LICENSE_KEY=foobar
 NEW_RELIC_LOG=stdout


### PR DESCRIPTION
We shouldn't support an unbounded number of features, or we have no way of limiting our memory usage.

20,000 features in one tile typically means we're drawing pretty dense features, so we shouldn't miss the extra features. But we can adjust this as needed through an environment variable to reflect:
- the realities of usage
- the memory limits of the hosting environment
- memory-saving improvements we might make down the road
