### PR TITLE
Don’t induce a stroke if we won’t see it

### DIFF
--- a/map/theme/filter.mss.template
+++ b/map/theme/filter.mss.template
@@ -3,20 +3,24 @@ Map {
 }
 
 #localdata {
+  [zoom >= 14] {
+    line-color: #b7aba5;
+    line-width:0.5;
+    line-opacity:0.5;
+  }
 	polygon-fill: #b7aba5;
-	line-color: #b7aba5;
-	line-width:0.5;
-	line-opacity:0.5;
 	polygon-opacity:0.85;
 }
 
 <% for(var i = 0; i < options.length; i++) { %>
 <% var pair = options[i]; %>
 #localdata['<%= pair.key %>'='<%= pair.value %>'] {
+  [zoom >= 14] {
+    line-color: <%= pair.color %>;
+    line-width:0.5;
+    line-opacity:0.5;
+  }
 	polygon-fill: <%= pair.color %>;
-	line-color: <%= pair.color %>;
-	line-width:0.5;
-	line-opacity:0.5;
 	polygon-opacity:0.85;
 }
 <% } %>

--- a/map/theme/style.mss
+++ b/map/theme/style.mss
@@ -3,19 +3,12 @@ Map {
 }
 
 #localdata {
-  [zoom < 14] {
-    line-color:#ef6d4a;
-    line-width:0;
-  }
-
   [zoom >= 14] {
     line-color:#fff;
     line-width:0.5;
+    line-opacity:0.5;
   }
 
-  line-color:#fff;
-  line-width:0.5;
-  line-opacity:0.5;
   polygon-opacity:0.85;
   polygon-fill:#ef6d4a;
 


### PR DESCRIPTION
By specifying the line color, we were causing nodetiles to send stroke commands to canvas. Even with a line width of 0, it seems there was a performance penalty.

With test URLs from [here](https://gist.github.com/prashtx/6da975d94803b06a3249/raw/df629a2f9ea5b19b073a938b8debed24f5316a6b/tiles-userflow-206.json), we save about 4.9% on the mean response time, maybe 3.5% on perc99, and apparently 17.5% on the max response time.

http://bit.ly/1pz6kHE
