### PR TITLE
Support reviewed responses

### DIFF
--- a/lib/controllers/tiles.js
+++ b/lib/controllers/tiles.js
@@ -222,8 +222,9 @@ function getOrCreateMapForSurveyId(surveyId, callback, options) {
       }
 
       // Support reviewed questions
+      // A question's review status is not explicitly part of the form, 
+      // but the field is stored as though it's a regular response
       questions.reviewed = {
-        text: 'Review status',
         answers: ['flagged', 'accepted', 'no response']
       };
 


### PR DESCRIPTION
If we want to map reviewed responses without them having an entry in a survey's Form object, we need to explicitly list the answer keys. 
