### PR TITLE
Use the last-modified field for verifying the cache

### DIFF
--- a/lib/controllers/tiles.js
+++ b/lib/controllers/tiles.js
@@ -144,16 +144,16 @@ function getOrCreateMapForSurveyId(surveyId, callback, options) {
 
   // Date filters
   if (options.until || options.after) {
-    query['entries.created'] = {};
+    query['entries.modified'] = {};
 
     if (options.until) {
       var until = new Date(parseInt(options.until, 10));
-      query['entries.created'].$lte = until;
+      query['entries.modified'].$lte = until;
     }
 
     if (options.after) {
       var after = new Date(parseInt(options.after, 10));
-      query['entries.created'].$gt = after;
+      query['entries.modified'].$gt = after;
     }
   }
 

--- a/lib/etag-cache.js
+++ b/lib/etag-cache.js
@@ -66,8 +66,8 @@ module.exports = function setup() {
         }
       }
     };
-    
-    query['properties.entries.created'] = { $gt: new Date(timestamp) };
+
+    query['properties.entries.modified'] = { $gt: new Date(timestamp) };
 
     // See if there have been new responses since the timestamp.
     Response.find(query).limit(1).lean().exec(function (error, docs) {

--- a/lib/models/Response.js
+++ b/lib/models/Response.js
@@ -30,6 +30,7 @@ entrySchema.set('toObject', {
       _id: ret._id,
       source: ret.source,
       created: ret.created,
+      modified: ret.modified,
       files: ret.files,
       responses: ret.responses
     };
@@ -70,7 +71,7 @@ responseSchema.pre('save', function (next) {
 responseSchema.index({
   'properties.survey': 1,
   'indexedGeometry': '2dsphere',
-  'entries.created': 1
+  'entries.modified': 1
 });
 
 // Index the survey ID + entry ID. We expose entry ID to clients.

--- a/lib/s3-cache.js
+++ b/lib/s3-cache.js
@@ -50,7 +50,7 @@ module.exports = function setup(options) {
         }
       }
     };
-    
+
     return query;
   }
 
@@ -64,7 +64,7 @@ module.exports = function setup(options) {
 
   function hasNew(survey, tile, timestamp, done) {
     var query = setupQuery(survey, tile);
-    query['entries.created'] = { $gt: new Date(timestamp) };
+    query['entries.modified'] = { $gt: new Date(timestamp) };
 
     Response.findOne(query).lean().exec(function (error, doc) {
       if (error) {


### PR DESCRIPTION
Also use it for after & until queries. I think users will expect modified entries to show up in date filter queries. I can separate that into a separate PR if needed. 
