### PR TITLE
Fix a problem where filtered answers might have the wrong color

### DIFF
--- a/lib/controllers/tiles.js
+++ b/lib/controllers/tiles.js
@@ -351,9 +351,8 @@ function getOrCreateMapForSurveyId(surveyId, callback, options) {
           var filterColor;
           if (filterValue !== undefined) {
             for (i = 0; i < answers.length; i += 1) {
-              if(answers[i] === filterValue) {
+              if (answers[i] === filterValue) {
                 filterColor = colors[i + 1];
-                console.log("ASSIGNED FILTER COLOR", filterColor, answers[i]);
               }
             }
           }


### PR DESCRIPTION
This has been bugging me for a long time. 

My hacky solution here is to just give every answer the same color if we're searching for a key-value pair. 

A more real solution would be to find the color, then generate a stylesheet that just gives every parcel that color -- no comparison test involved. That would also speed rendering, too, since we can skip a comparison step to associate a color with a k-v pair. 

The best solution would accept, via GET parameter, a color for every key-value pair, so that we can specify colors on the dashboard. 
