### PR TITLE
Use explicit deleted-entry timestamps for cache validation

### DIFF
--- a/lib/mongo-cache.js
+++ b/lib/mongo-cache.js
@@ -44,7 +44,7 @@ function makeTileName(req) {
   return req.path + queryString;
 }
 
-function setupQuery(survey, tile) {
+function setupQuery(survey, tile, deleted) {
   var bounds = tileToBounds(tile);
   var west = bounds[0][0];
   var south = bounds[0][1];
@@ -53,9 +53,14 @@ function setupQuery(survey, tile) {
 
   var boundingCoordinates = [ [ [west, south], [west, north], [east, north], [east, south], [west, south] ] ];
 
-  var query = {
-    'properties.survey': survey
-  };
+  var query = {};
+  if (deleted) {
+    query['properties.survey.deleted'] = true;
+    query['properties.survey.id'] = survey;
+  } else {
+    query['properties.survey'] = survey;
+  }
+
   query.indexedGeometry = {
     $geoIntersects: {
       $geometry: {
@@ -68,52 +73,28 @@ function setupQuery(survey, tile) {
   return query;
 }
 
-function getCount(survey, tile) {
-  var query = setupQuery(survey, tile);
-
-  return Response.countAsync(query);
-}
-
-// See if the tile has fewer than trueCount objects.
-function hasFewer(survey, tile, trueCount) {
-  if (trueCount === 0 || !trueCount) {
-    // The tile cannot have fewer than 0 objects.
-    return Promise.resolve(false);
-  }
-
-  var query = setupQuery(survey, tile);
-
-  // If there were N (trueCount) items before, then check for the Nth item. If
-  // it exists, then the tile has at least N items. Otherise, the tile has
-  // fewer than N items.
-  return Promise.resolve(
-    Response.find(query)
-    .select({ _id: 1 })
-    .skip(trueCount - 1)
-    .limit(1)
-    .lean()
-    .exec())
-  .then(function (docs) {
-    if (docs && docs.length > 0) {
-      return false;
-    }
-    return true;
-  });
-}
-
-function hasNew(survey, tile, timestamp) {
-  var query = setupQuery(survey, tile);
-  query['entries.modified'] = { $gt: new Date(timestamp) };
-
+function check(query) {
   return Promise.resolve(
     Response.findOne(query)
-    .select({ _id: 1 })
     .lean()
-    .exec())
-  .then(function (doc) {
+    .exec()
+  ).then(function (doc) {
     return !!doc;
   });
 }
+
+function hasNew(survey, tile, timestamp, done) {
+  var query = setupQuery(survey, tile);
+  query['entries.modified'] = { $gt: new Date(timestamp) };
+  return check(query);
+}
+
+function hasDeleted(survey, tile, timestamp, done) {
+  var query = setupQuery(survey, tile, true);
+  query['entries.modified'] = { $gt: new Date(timestamp) };
+  return check(query);
+}
+
 
 function getCacheItem(name) {
   return CacheItem.findOneAndUpdateAsync({
@@ -149,7 +130,7 @@ function saveCacheItem(name, contents) {
   });
 }
 
-function handleRender(req, res, countPromise, next) {
+function handleRender(req, res, next) {
   // We'll only apply this caching logic if res.send gets used. If we
   // stream data using res.write, then we bypass this functionality.
   var send = res.send;
@@ -172,17 +153,15 @@ function handleRender(req, res, countPromise, next) {
       return;
     }
 
-    countPromise.then(function (count) {
-      var name = makeTileName(req);
-      var contents = {
-        contentType: res.get('Content-Type'),
-        modified: new Date(),
-        count: count,
-        data: new Buffer(body)
-      };
+    var name = makeTileName(req);
+    var contents = {
+      contentType: res.get('Content-Type'),
+      modified: new Date(),
+      data: new Buffer(body)
+    };
 
-      return saveCacheItem(name, contents);
-    }).finally(function () {
+    return saveCacheItem(name, contents)
+    .finally(function () {
       send.call(res, body);
     });
   };
@@ -204,20 +183,20 @@ module.exports = function useCache(req, res, next) {
     if (!cached) {
       console.log('info at=mongo_cache event=miss reason=absent name=' + name);
       stopMetric.miss();
-      // Get the actual data count and render the tile.
-      handleRender(req, res, getCount(survey, tile), next);
+      // Render the tile.
+      handleRender(req, res, next);
       return;
     }
 
-    var fewerPromise = hasFewer(survey, tile, cached.contents.count);
+    var deletedPromise = hasDeleted(survey, tile, cached.contents.modified);
     var modifiedPromise = hasNew(survey, tile, cached.contents.modified);
 
-    return Promise.join(fewerPromise, modifiedPromise, function (hasFewer, hasNew) {
-      if (hasFewer) {
-        console.log('info at=mongo_cache event=miss reason=deletion cached_count=' + cached.contents.count + ' name=' + name);
+    return Promise.join(deletedPromise, modifiedPromise, function (hasDeleted, hasNew) {
+      if (hasDeleted) {
+        console.log('info at=mongo_cache event=miss reason=deletion name=' + name);
         stopMetric.miss();
         // Get the actual data count and render the tile.
-        handleRender(req, res, getCount(survey, tile), next);
+        handleRender(req, res, next);
         return;
       }
 
@@ -225,7 +204,7 @@ module.exports = function useCache(req, res, next) {
         console.log('info at=mongo_cache event=miss reason=modification name=' + name);
         stopMetric.miss();
         // Get the actual data count and render the tile.
-        handleRender(req, res, getCount(survey, tile), next);
+        handleRender(req, res, next);
         return;
       }
 
@@ -244,6 +223,6 @@ module.exports = function useCache(req, res, next) {
 
     stopMetric.miss();
 
-    handleRender(req, res, getCount(survey, tile), next);
+    handleRender(req, res, next);
   });
 };

--- a/lib/s3-cache.js
+++ b/lib/s3-cache.js
@@ -77,8 +77,8 @@ module.exports = function setup(options) {
     return check(query);
   }
 
-  function getS3Header(name, done) {
-    s3client.head(name)
+  function getS3Object(name, done) {
+    s3client.get(name)
     .on('response', function (s3res) {
       done(null, s3res);
     })
@@ -86,7 +86,7 @@ module.exports = function setup(options) {
     .end();
   }
 
-  var getS3HeaderAsync = Promise.promisify(getS3Header);
+  var getS3ObjectAsync = Promise.promisify(getS3Object);
 
   var makeTileName = (function () {
     var prefix = '/' + settings.name;
@@ -192,8 +192,9 @@ module.exports = function setup(options) {
     var survey = req.params.surveyId;
 
     var rendered = false;
+    var piped = false;
 
-    getS3HeaderAsync(name).then(function (s3res) {
+    getS3ObjectAsync(name).then(function (s3res) {
       // If the key is missing from S3, we need to render a tile.
       if (s3res.statusCode !== 200) {
         if (s3res.statusCode === 404) {
@@ -202,6 +203,7 @@ module.exports = function setup(options) {
           console.log('error at=s3_cache issue=validation_error status=' + s3res.statusCode + ' name=' + name);
           console.log('info at=s3_cache event=miss reason=access_error name=' + name);
         }
+        s3res.resume();
         stopMetric.miss();
         return handleRender(req, res, next);
       }
@@ -212,6 +214,7 @@ module.exports = function setup(options) {
         if (invalid && !rendered) {
           // There are new or modified entries, so we need to render a tile.
           console.log('info at=s3_cache event=miss reason=new_entries name=' + name);
+          s3res.resume();
           stopMetric.miss();
           rendered = true;
           handleRender(req, res, next);
@@ -226,6 +229,7 @@ module.exports = function setup(options) {
         if (invalid && !rendered) {
           // There are recently deleted entries, so we need to render a tile.
           console.log('info at=s3_cache event=miss reason=deletion name=' + name);
+          s3res.resume();
           stopMetric.miss();
           rendered = true;
           handleRender(req, res, next);
@@ -240,7 +244,40 @@ module.exports = function setup(options) {
           // Use the cached data
           console.log('info at=s3_cache event=hit url=' + s3res.req.url);
           stopMetric.hit();
-          res.redirect(s3res.req.url);
+          // If this is a conditional request, then check the etag/modification
+          // timestamp and potentially send back a 304 instead of sending the
+          // data. In that case, make sure we call s3res.resume().
+          var clientETag = req.get('if-none-match');
+          var clientModified = req.get('if-modified-since');
+          if ((clientETag && clientETag === s3res.headers.etag) ||
+              (clientModified && clientModified === s3res.headers['last-modified'])) {
+            res.set('etag', s3res.headers.etag);
+            res.set('last-modified', s3res.headers['last-modified']);
+            res.statusCode = 304;
+            s3res.resume();
+            res.end();
+          } else {
+            // If it's not a conditional request, or if the data has changed,
+            // then pipe the S3 data to the response.
+            res.set('content-type', s3res.headers['content-type']);
+            res.set('etag', s3res.headers.etag);
+            res.statusCode = 200;
+            s3res.pipe(res);
+          }
+          piped = true;
+
+          return new Promise(function (resolve, reject) {
+            s3res.on('end', function () {
+              resolve();
+            });
+            s3res.on('error', function (error) {
+              reject(error);
+            });
+          });
+        }
+      }).finally(function () {
+        if (!rendered && !piped) {
+          s3res.resume();
         }
       });
     }).catch(function (error) {

--- a/lib/s3-cache.js
+++ b/lib/s3-cache.js
@@ -1,16 +1,12 @@
 'use strict';
 
-var __ = require('lodash');
-var async = require('async');
 var concat = require('concat-stream');
-var projector = require("nodetiles-core").projector;
+var Promise = require('bluebird');
 var xml2js = require('xml2js');
 
 var metrics = require('./metrics/cache');
 var Response = require('./models/Response');
 var settings = require('./settings');
-
-var S3_CUSTOM_CACHE_HEADER = 'x-amz-meta-count';
 
 function tile2long(x, z) {
   return (x/Math.pow(2,z)*360-180);
@@ -30,7 +26,7 @@ function tileToBounds(tile) {
 module.exports = function setup(options) {
   var s3client = options.s3client;
 
-  function setupQuery(survey, tile) {
+  function setupQuery(survey, tile, deleted) {
     var bounds = tileToBounds(tile);
     var west = bounds[0][0];
     var south = bounds[0][1];
@@ -39,9 +35,14 @@ module.exports = function setup(options) {
 
     var boundingCoordinates = [ [ [west, south], [west, north], [east, north], [east, south], [west, south] ] ];
 
-    var query = {
-      'properties.survey': survey
-    };
+    var query = {};
+    if (deleted) {
+      query['properties.survey.deleted'] = true;
+      query['properties.survey.id'] = survey;
+    } else {
+      query['properties.survey'] = survey;
+    }
+
     query.indexedGeometry = {
       $geoIntersects: {
         $geometry: {
@@ -54,24 +55,26 @@ module.exports = function setup(options) {
     return query;
   }
 
-  function getCount(survey, tile, done) {
-    var query = setupQuery(survey, tile);
-
-    Response.count(query, function (error, count) {
-      done(error, count);
+  function check(query) {
+    return Promise.resolve(
+      Response.findOne(query)
+      .lean()
+      .exec()
+    ).then(function (doc) {
+      return !!doc;
     });
   }
 
-  function hasNew(survey, tile, timestamp, done) {
+  function checkModified(survey, tile, timestamp, done) {
     var query = setupQuery(survey, tile);
     query['entries.modified'] = { $gt: new Date(timestamp) };
+    return check(query);
+  }
 
-    Response.findOne(query).lean().exec(function (error, doc) {
-      if (error) {
-        return done(error);
-      }
-      done(null, doc !== null);
-    });
+  function checkDeleted(survey, tile, timestamp, done) {
+    var query = setupQuery(survey, tile, true);
+    query['entries.modified'] = { $gt: new Date(timestamp) };
+    return check(query);
   }
 
   function getS3Header(name, done) {
@@ -82,6 +85,8 @@ module.exports = function setup(options) {
     .on('error', done)
     .end();
   }
+
+  var getS3HeaderAsync = Promise.promisify(getS3Header);
 
   var makeTileName = (function () {
     var prefix = '/' + settings.name;
@@ -124,7 +129,6 @@ module.exports = function setup(options) {
           'Content-Length': body.length,
           'Content-Type': res.get('Content-Type')
         };
-        headers[S3_CUSTOM_CACHE_HEADER] = res.getHeader(S3_CUSTOM_CACHE_HEADER);
         var buffer = new Buffer(body);
 
         handleS3Error = function handleS3Error(error) {
@@ -187,53 +191,9 @@ module.exports = function setup(options) {
     var tile = res.locals.tile;
     var survey = req.params.surveyId;
 
-    function handleError(error) {
-      if (!error) {
-        return false;
-      }
-      console.log('error at=s3_cache issue=validation_error name=' + name);
-      console.log(error);
-      console.log('info at=s3_cache event=miss reason=validation_error name=' + name);
-      stopMetric.miss();
+    var rendered = false;
 
-      // We need to render a tile.
-      handleRender(req, res, next);
-      return true;
-    }
-
-    async.parallel([
-      // Get the count
-      __.bind(getCount, this, survey, tile),
-      // Check if the key is in S3
-      __.bind(getS3Header, this, name)
-    ], function (error, values) {
-      if (handleError(error)) {
-        return;
-      }
-
-      var trueCount = values[0];
-      var s3res = values[1];
-      var s3Count;
-
-      res.setHeader(S3_CUSTOM_CACHE_HEADER, trueCount);
-
-      function handleValidation(error, hasNew) {
-        if (handleError(error)) {
-          return;
-        }
-
-        if (hasNew) {
-          // There are new responses, so we need to render a tile.
-          console.log('info at=s3_cache event=miss reason=new_entries name=' + name);
-          stopMetric.miss();
-          return handleRender(req, res, next);
-        }
-
-        console.log('info at=s3_cache event=hit url=' + s3res.req.url);
-        stopMetric.hit();
-        res.redirect(s3res.req.url);
-      }
-
+    getS3HeaderAsync(name).then(function (s3res) {
       // If the key is missing from S3, we need to render a tile.
       if (s3res.statusCode !== 200) {
         if (s3res.statusCode === 404) {
@@ -246,19 +206,61 @@ module.exports = function setup(options) {
         return handleRender(req, res, next);
       }
 
-      // The key is in S3. Now we use it to see if the cached tile is still
-      // valid.
-      s3Count = parseInt(s3res.headers[S3_CUSTOM_CACHE_HEADER], 10);
+      // Check if there are new/modified entries.
+      var modificationTest = checkModified(survey, tile, s3res.headers['last-modified']).then(function (invalid) {
+        // TODO: cancel the promise if we have already rendered.
+        if (invalid && !rendered) {
+          // There are new or modified entries, so we need to render a tile.
+          console.log('info at=s3_cache event=miss reason=new_entries name=' + name);
+          stopMetric.miss();
+          rendered = true;
+          handleRender(req, res, next);
+        }
 
-      if (s3Count !== trueCount) {
-        // The counts don't match, so we know the cached tile is invalid.
-        console.log('info at=s3_cache event=miss reason=mismatched_count count=' + trueCount + ' cached_count=' + s3Count + ' name=' + name);
+        return invalid;
+      });
+
+      // Check if we have deleted any entries.
+      var deletionTest = checkDeleted(survey, tile, s3res.headers['last-modified']).then(function (invalid) {
+        // TODO: cancel the promise if we have already rendered.
+        if (invalid && !rendered) {
+          // There are recently deleted entries, so we need to render a tile.
+          console.log('info at=s3_cache event=miss reason=deletion name=' + name);
+          stopMetric.miss();
+          rendered = true;
+          handleRender(req, res, next);
+        }
+
+        return invalid;
+      });
+
+      return Promise.join(modificationTest, deletionTest)
+      .spread(function (hasModified, hasDeleted) {
+        if (!hasModified && !hasDeleted) {
+          // Use the cached data
+          console.log('info at=s3_cache event=hit url=' + s3res.req.url);
+          stopMetric.hit();
+          res.redirect(s3res.req.url);
+        }
+      });
+    }).catch(function (error) {
+      if (!rendered) {
+        console.log('error at=s3_cache issue=validation_error name=' + name);
+        console.log(error);
+        console.log(error.stack);
+        console.log('info at=s3_cache event=miss reason=validation_error name=' + name);
         stopMetric.miss();
-        return handleRender(req, res, next);
-      }
 
-      // Check if there are new responses.
-      hasNew(survey, tile, s3res.headers['last-modified'], handleValidation);
+        // We need to render a tile.
+        handleRender(req, res, next);
+      } else {
+        // We encountered an error after kicking off a render. The cache miss
+        // has been tracked, and the response is now out of our hands, so we
+        // just need to log the error.
+        console.log('error at=s3_cache issue=validation_error name=' + name);
+        console.log(error);
+        console.log(error.stack);
+      }
     });
   };
 };


### PR DESCRIPTION
Rely on explicit deleted-entry documents to indicate that cached data is invalid, rather than matching counts. We now check for an active entry with a modification time later than the cached data and for a deleted entry with a modification time later than the cached data. This eliminates the slow count query entirely, which helps both the cache hit and cache miss latency.

Stream data from S3 to the client rather than issuing a redirect. The latency overhead for a HEAD request to S3 can be significant, and we ended up forcing the client to incur the same latency when it followed the redirect. Instead, we request the whole object. If the cached data is stale, we don't use the actual object contents, only the header info. If the cached data is good, we either issue a 304 Not Modified or stream the data to the client. This method also lets us apply gzip encoding more easily.

/cc @hampelm 
