### PR TITLE
Update the Survey model to match the API

### DIFF
--- a/lib/models/Response.js
+++ b/lib/models/Response.js
@@ -40,7 +40,10 @@ entrySchema.set('toObject', {
 var responseSchema = new mongoose.Schema({
   __v: { type: Number, select: false },
   properties: {
-    survey: String,
+    // survey is a String for active Response docs and an object for "zombie"
+    // Response docs that hold deleted entries.
+    // TODO: add validation or a custom type for the survey field
+    survey: mongoose.SchemaTypes.Mixed,
     humanReadableName: String,
     object_id: { type: String },
     centroid: []
@@ -283,4 +286,3 @@ responseSchema.statics.getBounds = function getBounds(survey, done) {
 };
 
 var Response = module.exports = mongoose.model('Response', responseSchema, 'responses');
-


### PR DESCRIPTION
Mongoose uses the model to interpret query documents, so we need it to know that `properties.survey` doesn't have to be a string.