### PR TITLE
Force mongo to use a specific index

### DIFF
--- a/lib/mongo-cache.js
+++ b/lib/mongo-cache.js
@@ -89,7 +89,12 @@ function setupQuery(survey, tile, deleted) {
 function check(query) {
   return Promise.resolve(
     Response.findOne(query)
-    .lean()
+    .select({ _id: 1 })
+    .hint({
+      'properties.survey': 1,
+      indexedGeometry: '2dsphere',
+      'entries.modified': 1
+    }).lean()
     .exec()
   ).then(function (doc) {
     return !!doc;

--- a/lib/s3-cache.js
+++ b/lib/s3-cache.js
@@ -71,7 +71,12 @@ module.exports = function setup(options) {
   function check(query) {
     return Promise.resolve(
       Response.findOne(query)
-      .lean()
+      .select({ _id: 1 })
+      .hint({
+        'properties.survey': 1,
+        indexedGeometry: '2dsphere',
+        'entries.modified': 1
+      }).lean()
       .exec()
     ).then(function (doc) {
       return !!doc;


### PR DESCRIPTION
For some reason, MongoDB 2.4 does not always choose the right index here. It does use an index, but using an inefficient one leads to a large index scan.

/cc @hampelm 
