### PR TITLE
Improve point and linestring styles

### DIFF
--- a/map/theme/style.mss
+++ b/map/theme/style.mss
@@ -16,9 +16,30 @@ Map {
     polygon-fill:#ef6d4a;
   }
 
+  [GEOMETRY = LineString]::outline {
+    line-width: 4;
+    line-cap: round;
+
+    [zoom >= 15] {
+      line-width: 5;
+    }
+    [zoom >= 16] {
+      line-width: 6;
+    }
+    [zoom >= 17] {
+      line-width: 7;
+    }
+    [zoom >= 18] {
+      line-width: 8;
+    }
+
+    line-color: #fff3da;
+    line-opacity: 1;
+  }
 
   [GEOMETRY = LineString] {
     line-width: 2;
+    line-cap: round;
 
     [zoom >= 15] {
       line-width: 3;

--- a/map/theme/style.mss
+++ b/map/theme/style.mss
@@ -3,13 +3,60 @@ Map {
 }
 
 #localdata {
-  [zoom >= 14] {
-    line-color:#fff;
-    line-width:0.5;
-    line-opacity:0.5;
+
+  [GEOMETRY = MultiPolygon],
+  [GEOMETRY = Polygon] {
+    [zoom >= 14] {
+      line-color:#fff;
+      line-width:0.5;
+      line-opacity:0.5;
+    }
+
+    polygon-opacity:0.85;
+    polygon-fill:#ef6d4a;
   }
 
-  polygon-opacity:0.85;
-  polygon-fill:#ef6d4a;
+
+  [GEOMETRY = LineString] {
+    line-width: 2;
+
+    [zoom >= 15] {
+      line-width: 3;
+    }
+    [zoom >= 16] {
+      line-width: 4;
+    }
+    [zoom >= 17] {
+      line-width: 5;
+    }
+    [zoom >= 18] {
+      line-width: 6;
+    }
+
+    line-color: #ef6d4a;
+    line-opacity: 0.9;
+  }
+
+
+  [GEOMETRY=Point] {
+    marker-line-width: 1;
+    marker-width: 8;
+
+    [zoom >= 14] {
+      marker-line-width: 1;
+      marker-width: 10;
+    }
+
+    [zoom >= 16] {
+      marker-line-width: 1;
+      marker-width: 12;
+    }
+
+    marker-type: ellipse;
+    marker-line-color: #fff3da;
+    marker-fill: #ef6d4a;
+    marker-fill-opacity: 0.9;
+    marker-line-opacity: 1;
+  }
 
 }


### PR DESCRIPTION
Improves point and linestring styles at close and far zooms (point display still needs work at far zooms) . Increases accuracy at closer zoom styles. 

![screen shot 2015-04-20 at 5 59 24 pm](https://cloud.githubusercontent.com/assets/86435/7241453/0a34b728-e787-11e4-93bf-f6097a8c2d25.png)
![screen shot 2015-04-20 at 5 59 09 pm](https://cloud.githubusercontent.com/assets/86435/7241455/0a364318-e787-11e4-91ac-c614e55ac0f3.png)
![screen shot 2015-04-20 at 5 58 58 pm](https://cloud.githubusercontent.com/assets/86435/7241456/0a39747a-e787-11e4-8ce7-e2546dc64d74.png)
![screen shot 2015-04-20 at 5 58 50 pm](https://cloud.githubusercontent.com/assets/86435/7241457/0a39fb70-e787-11e4-9f19-9fae73daec70.png)
![screen shot 2015-04-20 at 6 03 03 pm](https://cloud.githubusercontent.com/assets/86435/7241533/89b4e39c-e787-11e4-91ed-132dea0cf3f7.png)
