### PR TITLE
Fix badly-ordered util.inherits

### DIFF
--- a/lib/controllers/tiles.js
+++ b/lib/controllers/tiles.js
@@ -146,7 +146,7 @@ function getMap(options, callback) {
     projection: 'EPSG:4326',
     query: query,
     select: select,
-    grid: grid,
+    grid: grid
   });
 
   // Wrap the datasource.getShapes call so we can measure its duration

--- a/lib/datasources/responses.js
+++ b/lib/datasources/responses.js
@@ -27,6 +27,8 @@ function ToFeatures(options) {
   this.procTimer.pause();
 }
 
+util.inherits(ToFeatures, stream.Transform);
+
 ToFeatures.prototype._transform = function transform(item, encoding, done) {
   this.procTimer.start();
 
@@ -52,8 +54,6 @@ ToFeatures.prototype._transform = function transform(item, encoding, done) {
   this.procTimer.pause();
   done();
 };
-
-util.inherits(ToFeatures, stream.Transform);
 
 
 exports.create = function create(options) {


### PR DESCRIPTION
Having util.inherits in the wrong order caused mongoose to throw an error that wasn't implemented. 