### PR TITLE
Allow definition of feature/parcel layers via GET

### DIFF
--- a/lib/controllers/tile-json.js
+++ b/lib/controllers/tile-json.js
@@ -77,8 +77,15 @@ exports.get = function get(req, res, next) {
 
     layer.saveDefinition(layerId, data)
     .then(function () {
+      var path;
+      if (surveyId) {
+        path = pathPrefix(req) + '/surveys/' + surveyId + '/layers/' + layerId;
+      } else {
+        // This is a feature layer request
+        path = pathPrefix(req) + '/features/layers/' + layerId;
+      }
       var tileJson = generateTileJSON({
-        path: pathPrefix(req) + '/surveys/' + surveyId + '/layers/' + layerId,
+        path: path,
         query: req.query
       });
       res.jsonp(tileJson);


### PR DESCRIPTION
As with the survey-based tile layers, using GET requests lets us proxy requests through the API and put off modifications there.

/cc @hampelm 