### PR TITLE
Improve performance

### DIFF
--- a/lib/cache/s3-cache.js
+++ b/lib/cache/s3-cache.js
@@ -13,7 +13,7 @@ var util = require('./cache-util');
 module.exports = function setup(options) {
   var s3client = options.s3client;
 
-  function setupQuery(survey, tile, deleted) {
+  function setupQuery(survey, tile, deleted, conditions) {
     var bounds = util.tileToBounds(tile);
     var west = bounds[0][0];
     var south = bounds[0][1];
@@ -22,7 +22,21 @@ module.exports = function setup(options) {
 
     var boundingCoordinates = [ [ [west, south], [west, north], [east, north], [east, south], [west, south] ] ];
 
-    var query = {};
+    var query = {
+      indexedGeometry: {
+        $geoIntersects: {
+          $geometry: {
+            type: 'Polygon',
+            coordinates: boundingCoordinates
+          }
+        }
+      }
+    };
+
+    Object.keys(conditions).forEach(function (key) {
+      query[key] = conditions[key];
+    });
+
     if (deleted) {
       // Don't consider key order.
       // We don't use dot notation, because it doesn't fully specify the value
@@ -39,18 +53,27 @@ module.exports = function setup(options) {
           deleted: true
         }
       }];
+      query = {
+        $or: [{
+          'properties.survey': {
+            deleted: true,
+            id: survey
+          }
+        }, {
+          'properties.survey': {
+            id: survey,
+            deleted: true
+          }
+        }].map(function (condition) {
+          Object.keys(query).forEach(function (key) {
+            condition[key] = query[key];
+          });
+          return condition;
+        })
+      };
     } else {
       query['properties.survey'] = survey;
     }
-
-    query.indexedGeometry = {
-      $geoIntersects: {
-        $geometry: {
-          type: 'Polygon',
-          coordinates: boundingCoordinates
-        }
-      }
-    };
 
     return query;
   }
@@ -71,14 +94,16 @@ module.exports = function setup(options) {
   }
 
   function checkModified(survey, tile, timestamp, done) {
-    var query = setupQuery(survey, tile);
-    query['entries.modified'] = { $gt: new Date(timestamp) };
+    var query = setupQuery(survey, tile, false, {
+      'entries.modified': { $gt: new Date(timestamp) }
+    });
     return check(query);
   }
 
   function checkDeleted(survey, tile, timestamp, done) {
-    var query = setupQuery(survey, tile, true);
-    query['entries.modified'] = { $gt: new Date(timestamp) };
+    var query = setupQuery(survey, tile, true, {
+      'entries.modified': { $gt: new Date(timestamp) }
+    });
     return check(query);
   }
 

--- a/lib/controllers/features.js
+++ b/lib/controllers/features.js
@@ -167,6 +167,31 @@ exports.render = function render(req, res, next) {
   });
 };
 
+function selectFields(item, select) {
+    var ret = {};
+    Object.keys(item).forEach(function (field) {
+      if (field === 'object_id' || !!select[field]) {
+        if (typeof select[field] === 'object') {
+          ret[field] = selectFields(item[field], select[field]);
+        } else {
+          ret[field] = item[field];
+        }
+      }
+    });
+    return ret;
+}
+
+function stripGridFields(grid, select) {
+  var stripped = {};
+  Object.keys(grid.data).forEach(function (key) {
+    stripped[key] = selectFields(grid.data[key], select);
+  });
+  return {
+    grid: grid.grid,
+    keys: grid.keys,
+    data: stripped
+  };
+}
 
 // TODO: Support grids for features
 // TODO: handle the routing/http stuff ourselves and just use nodetiles as a
@@ -220,7 +245,7 @@ exports.renderGrids = function renderGrids(req, res, next) {
         // Stop the metric timer whether or not this succeeded.
         stopTimer();
       }).then(function (grid) {
-        res.jsonp(grid);
+        res.jsonp(stripGridFields(grid, options.select));
       });
     });
   }).catch(function (error) {

--- a/lib/controllers/tile-json.js
+++ b/lib/controllers/tile-json.js
@@ -7,32 +7,53 @@ var settings = require('../settings');
 
 function pathPrefix(req) {
   if (!settings.prefix) {
-    return 'https://' + req.headers.host;
+    return ['https://' + req.headers.host];
   }
-
+  
   return settings.prefix;
+}
+
+function surveyPaths(req) {
+  return pathPrefix(req).map(function (path) {
+    return path + '/' + req.params.surveyId;
+  });
 }
 
 // Generate tilejson
 function generateTileJSON(options) {
-  var path = options.path;
+  var paths = options.paths;
+
+  var grids = [];
+  var tiles = [];
+  
+  var filterPath;
+  var tileQuery;
+  var gridQuery;
 
   // The tile path changes if we are adding data filters
   if (options.filterPath) {
-    path = path + '/' + options.filterPath;
+    filterPath = '/' + options.filterPath;
+  } else {
+    filterPath = '';
   }
-
-  // Construct the URLs for the UTF grids and the tiles.
-  var grid = path + "/utfgrids/{z}/{x}/{y}.json?callback={cb}";
-  var tiles = path + "/tiles/{z}/{x}/{y}.png";
 
   // Add on any filters or other parameters. Right now, this just handles dates,
   // but will at some point also have the filters.
   if (options.query) {
     var query = querystring.stringify(options.query);
-    tiles = tiles + '?' + query;
-    grid = grid + '&' + query;
+    tileQuery = '?' + query;
+    gridQuery = '&' + query;
+  } else {
+    tileQuery = '';
+    gridQuery = '';
   }
+
+  paths.forEach(function (path) {
+    // Construct the URLs for the UTF grids and the tiles.
+    grids.push(path + filterPath + '/utfgrids/{z}/{x}/{y}.json?callback={cb}' + gridQuery);
+    tiles.push(path + filterPath + '/tiles/{z}/{x}/{y}.png' + tileQuery);
+  });
+
 
   var tilejson = {
     "basename" : "localdata.tiles",
@@ -40,7 +61,7 @@ function generateTileJSON(options) {
     "center" : [0, 0, 2],
     "description" : "Lovingly crafted with Node and node-canvas.",
     "attribution" : "LocalData",
-    "grids"       : [grid],
+    "grids"       : grids,
     "id"          : "map",
     "legend"      : "",
     "maxzoom"     : 30,
@@ -48,7 +69,7 @@ function generateTileJSON(options) {
     "name"        : '',
     "scheme"      : 'xyz',
     "template"    : '',
-    "tiles"       : [tiles],
+    "tiles"       : tiles,
     "version"     : "1.0.0",
     "webpage"     : "http://localdata.com"
   };
@@ -77,15 +98,16 @@ exports.get = function get(req, res, next) {
 
     layer.saveDefinition(layerId, data)
     .then(function () {
-      var path;
-      if (surveyId) {
-        path = pathPrefix(req) + '/surveys/' + surveyId + '/layers/' + layerId;
-      } else {
+      var paths = pathPrefix(req).map(function (path) {
+        if (surveyId) {
+          return path + '/surveys/' + surveyId + '/layers/' + layerId;
+        }
         // This is a feature layer request
-        path = pathPrefix(req) + '/features/layers/' + layerId;
-      }
+        return path + '/features/layers/' + layerId;
+      });
+
       var tileJson = generateTileJSON({
-        path: path,
+        paths: paths,
         query: req.query
       });
       res.jsonp(tileJson);
@@ -97,7 +119,7 @@ exports.get = function get(req, res, next) {
   } else {
     // No layer definition, so we fall back to the legacy URLs
     var tileJson = generateTileJSON({
-      path: pathPrefix(req) + '/' + surveyId,
+      paths: surveyPaths(req),
       query: req.query
     });
     res.jsonp(tileJson);
@@ -114,17 +136,17 @@ exports.post = function post(req, res) {
   .then(function () {
 
     // Set up the correct base path
-    var path;
-    if (surveyId) {
-      path = pathPrefix(req) + '/surveys/' + surveyId + '/layers/' + layerId;
-    } else {
+    var paths = pathPrefix(req).map(function (path) {
+      if (surveyId) {
+        return path + '/surveys/' + surveyId + '/layers/' + layerId;
+      }
       // This is a feature layer request
-      path = pathPrefix(req) + '/features/layers/' + layerId;
-    }
+      return path + '/features/layers/' + layerId;
+    });
 
     // Create the tileJSON
     var tileJson = generateTileJSON({
-      path: path,
+      paths: paths,
       query: req.query
     });
     res.jsonp(tileJson);
@@ -154,7 +176,7 @@ exports.getFilteredKey = function getFilteredKey(req, res, next) {
   var key = req.params.key;
   var filterPath = 'filter/' + key;
   var tileJson = generateTileJSON({
-    path: pathPrefix(req) + '/' + req.params.surveyId,
+    paths: surveyPaths(req),
     filterPath: filterPath,
     query: req.query
   });
@@ -166,7 +188,7 @@ exports.getFilteredKeyValue = function getFilteredKey(req, res, next) {
 
   var filterPath = 'filter/' + req.params.key + '/' + req.params.val;
   var tileJson = generateTileJSON({
-    path: pathPrefix(req) + '/' + req.params.surveyId,
+    paths: surveyPaths(req),
     filterPath: filterPath,
     query: req.query
   });

--- a/lib/postgres.js
+++ b/lib/postgres.js
@@ -4,6 +4,6 @@ var settings = require('./settings');
 
 exports.pg = knex({
   client: 'pg',
-  pool: { min: 4, max: 10 },
+  pool: { min: settings.psqlPoolMin, max: settings.psqlPoolMax },
   connection: settings.psqlConnectionString
 });

--- a/lib/postgres.js
+++ b/lib/postgres.js
@@ -4,5 +4,6 @@ var settings = require('./settings');
 
 exports.pg = knex({
   client: 'pg',
+  pool: { min: 4, max: 10 },
   connection: settings.psqlConnectionString
 });

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -20,6 +20,15 @@ settings.s3Bucket = process.env.S3_BUCKET;
 settings.psqlConnectionString = process.env.DATABASE_URL;
 settings.featuresTable = process.env.FEATURES_TABLE;
 
+settings.psqlPoolMin = parseInt(process.env.PSQL_POOL_MIN, 10);
+if (isNaN(settings.psqlPoolMin)) {
+  settings.psqlPoolMin = 4;
+}
+settings.psqlPoolMax = parseInt(process.env.PSQL_POOL_MAX, 10);
+if (isNaN(settings.psqlPoolMax)) {
+  settings.psqlPoolMax = 10;
+}
+
 settings.port = process.env.PORT || process.argv[2] || 3001;
 settings.mongo = process.env.MONGO || 'mongodb://localhost:27017/localdata_production';
 

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -22,7 +22,19 @@ settings.featuresTable = process.env.FEATURES_TABLE;
 
 settings.port = process.env.PORT || process.argv[2] || 3001;
 settings.mongo = process.env.MONGO || 'mongodb://localhost:27017/localdata_production';
-settings.prefix = process.env.PREFIX;
+
+// The prefix should actually be an array of tile path prefixes, specified as
+// JSON. We support the original interpretation, though, of the prefix as a
+// single path prefix specified directly as a simple string.
+if (process.env.PREFIX && Object.prototype.toString.call(process.env.PREFIX === '[object String]')) {
+  if (process.env.PREFIX.trim()[0] === '[') {
+    // JSON array
+    settings.prefix = JSON.parse(process.env.PREFIX)
+  } else {
+    // Legacy value
+    settings.prefix = [process.env.PREFIX];
+  }
+}
 
 settings.noAnswer = 'no response';
 settings.unstructuredAnswer = 'response';

--- a/sample.env
+++ b/sample.env
@@ -4,8 +4,8 @@ NAME="my-staging-service"
 # MongoDB connection string
 MONGO="mongodb://username:password@host:port/database"
 
-# Prefix for the tile URLs that we present through tile.json
-PREFIX="//localhost:4334"
+# JSON array of prefixes for the tile URLs that we present through tile.json
+PREFIX='["//localhost:4334"]'
 
 # S3 parameters, if you want to cache rendered tiles on S3
 S3_KEY="foo"

--- a/sample.env
+++ b/sample.env
@@ -4,6 +4,15 @@ NAME="my-staging-service"
 # MongoDB connection string
 MONGO="mongodb://username:password@host:port/database"
 
+# PostgreSQL connection string
+DATABASE_URL='postgres://username:password@host:port/database?ssl=true'
+# PostgreSQL table for feature tiles
+FEATURES_TABLE="features"
+
+# Optional postgres pool bounds (defaults to min: 4, max: 10)
+#PSQL_POOL_MIN=4
+#PSQL_POOL_MAX=10
+
 # JSON array of prefixes for the tile URLs that we present through tile.json
 PREFIX='["//localhost:4334"]'
 
@@ -17,6 +26,10 @@ CACHE="mongo"
 
 # Configure the maximum number of responses rendered per tile. The default is 20,000.
 #MAX_COUNT=18000
+
+# Zoom limit for rendering feature tiles (nothing rendered when zoomed farther
+# out). Default is 12.
+#MAX_FEATURE_ZOOM=12
 
 # New Relic parameters, if you want to use New Relic instrumentation
 NEW_RELIC_LICENSE_KEY=foobar


### PR DESCRIPTION
Tweak survey data queries to take better advantage of an index.

Support more involved `select` fields for feature tiles, so we can avoid bloated UTFGrid data. Support multiple paths, so we can set up alternate domains and let clients issue more tile requests in parallel.

/cc @hampelm 