### PR TITLE
Make JSONP optional for UTFgrids

### DIFF
--- a/lib/controllers/tile-json.js
+++ b/lib/controllers/tile-json.js
@@ -2,6 +2,8 @@
 
 var querystring = require('querystring');
 
+var _ = require('lodash');
+
 var layer = require('../layer');
 var settings = require('../settings');
 
@@ -21,14 +23,16 @@ function surveyPaths(req) {
 
 // Generate tilejson
 function generateTileJSON(options) {
+  // The construction of grid and tile paths could be more efficient, but it
+  // does not happen often, and there are not many paths to build, so we should
+  // shoot for robustness and clarity instead.
   var paths = options.paths;
+  var jsonp = true;
 
-  var grids = [];
-  var tiles = [];
-  
   var filterPath;
-  var tileQuery;
-  var gridQuery;
+  var query = options.query;
+  var tileQuery = {};
+  var gridQuery = {};
 
   // The tile path changes if we are adding data filters
   if (options.filterPath) {
@@ -36,22 +40,55 @@ function generateTileJSON(options) {
   } else {
     filterPath = '';
   }
+  
+  // Support JSONP for the UTF grids.
+
+  if (query && query.jsonp) {
+    // We default to true but allow the client to specify 'false'.
+    if (query.jsonp === 'false') {
+      jsonp = false;
+    }
+    // Don't include this option in the tile/grid querystrings.
+    query = _.omit(query, 'jsonp');
+  }
+
+  if (jsonp) {
+    _.merge(gridQuery, {
+      callback: '{cb}'
+    });
+  }
 
   // Add on any filters or other parameters. Right now, this just handles dates,
   // but will at some point also have the filters.
-  if (options.query) {
-    var query = querystring.stringify(options.query);
-    tileQuery = '?' + query;
-    gridQuery = '&' + query;
-  } else {
-    tileQuery = '';
-    gridQuery = '';
+  if (query) {
+    _.merge(tileQuery, query);
+    _.merge(gridQuery, query);
   }
+  
+  var tileQueryString = querystring.stringify(tileQuery);
+  // Avoid escaping the callback template string, if one is present, since we are really building
+  // a template for a URI, not the actual valid URI itself.
+  var gridQueryString = querystring.stringify(gridQuery, null, null, {
+    encodeURIComponent: function (str) {
+      if (str === '{cb}') {
+        return str;
+      }
+      return querystring.escape(str);
+    }
+  });
 
-  paths.forEach(function (path) {
-    // Construct the URLs for the UTF grids and the tiles.
-    grids.push(path + filterPath + '/utfgrids/{z}/{x}/{y}.json?callback={cb}' + gridQuery);
-    tiles.push(path + filterPath + '/tiles/{z}/{x}/{y}.png' + tileQuery);
+  // Construct the URLs for the UTF grids and the tiles.
+  var grids = paths.map(function (path) {
+    return _.compact([
+      path + filterPath + '/utfgrids/{z}/{x}/{y}.json',
+      gridQueryString
+    ]).join('?');
+  });
+  var tiles = paths.map(function (path) {
+    return _.compact([
+      path + filterPath + '/tiles/{z}/{x}/{y}.png',
+      tileQueryString
+    ]).join('?');
   });
 
 


### PR DESCRIPTION
Support a `jsonp=false` querystring parameter when requesting the TileJSON for both normal layers and legacy survey layers. The `grid` field in the TileJSON will then omit the callback template, so the client can use CORS JSON requests rather than JSONP requests.