### PR TITLE
Improve content-type handling and Express 4.x usage

### DIFF
--- a/lib/cache/etag-cache.js
+++ b/lib/cache/etag-cache.js
@@ -13,7 +13,6 @@
  * 304 Not Modified status.
  */
 
-var async = require('async');
 var lru = require('lru-cache');
 
 var metrics = require('../metrics/cache');

--- a/lib/cache/etag-cache.js
+++ b/lib/cache/etag-cache.js
@@ -117,7 +117,7 @@ module.exports = function setup() {
 
         // The responses haven't changed for this tile.
         res.set('ETag', etag);
-        res.send(304);
+        res.sendStatus(304);
 
         // Update the cache entry.
         cache.set(req.url, {
@@ -130,7 +130,7 @@ module.exports = function setup() {
     // We'll only apply this ETag caching logic if res.send gets used. If we
     // stream data using res.write, then we bypass this functionality.
     var send = res.send;
-    res.send = function (status, body) {
+    res.send = function (body) {
       var etag = res.get('etag');
       send.apply(res, arguments);
 

--- a/lib/cache/mongo-cache.js
+++ b/lib/cache/mongo-cache.js
@@ -155,22 +155,12 @@ function handleRender(req, res, next) {
   // We'll only apply this caching logic if res.send gets used. If we
   // stream data using res.write, then we bypass this functionality.
   var send = res.send;
-  res.send = function (_status, _body) {
+  res.send = function (_body) {
     var body;
-    var status;
-
-    // Express lets callers swap the body and status code, so we need to
-    // support that, too.
-    if (typeof _status === 'number') {
-      body = _body;
-      status = _status;
-    } else {
-      body = _status;
-      status = 200;
-    }
+    var status = res.status() || 200;
 
     if (status !== 200) {
-      send.call(res, _status, _body);
+      send.call(res, _body);
       return;
     }
 

--- a/lib/cache/mongo-cache.js
+++ b/lib/cache/mongo-cache.js
@@ -101,13 +101,13 @@ function check(query) {
   });
 }
 
-function hasNew(survey, tile, timestamp, done) {
+function hasNew(survey, tile, timestamp) {
   var query = setupQuery(survey, tile);
   query['entries.modified'] = { $gt: new Date(timestamp) };
   return check(query);
 }
 
-function hasDeleted(survey, tile, timestamp, done) {
+function hasDeleted(survey, tile, timestamp) {
   var query = setupQuery(survey, tile, true);
   query['entries.modified'] = { $gt: new Date(timestamp) };
   return check(query);

--- a/lib/cache/s3-cache-features.js
+++ b/lib/cache/s3-cache-features.js
@@ -1,16 +1,12 @@
 'use strict';
 
-var __ = require('lodash');
-var async = require('async');
 var concat = require('concat-stream');
 var knex = require('knex');
-var projector = require("nodetiles-core").projector;
 var Promise = require('bluebird');
 var xml2js = require('xml2js');
 
 var metrics = require('../metrics/cache');
 var pg = require('../postgres').pg;
-var Response = require('../models/Response');
 var settings = require('../settings');
 var util = require('./cache-util');
 
@@ -44,7 +40,7 @@ module.exports = function setup(options) {
     var query = pg.select('timestamp')
       .from(settings.featuresTable)
       .where(makeEnvelope(tile))
-      .andWhere(knex.raw("timestamp > to_timestamp(?)", [timestamp]))
+      .andWhere(knex.raw('timestamp > to_timestamp(?)', [timestamp]))
       .limit(1);
 
     return query;
@@ -177,7 +173,6 @@ module.exports = function setup(options) {
 
     var name = makeTileName(req);
     var tile = res.locals.tile;
-    var survey = req.params.surveyId;
 
     var rendered = false;
     var piped = false;

--- a/lib/cache/s3-cache.js
+++ b/lib/cache/s3-cache.js
@@ -155,10 +155,16 @@ module.exports = function setup(options) {
       if (s3client) {
         saveMetric = metrics.s3Storage();
         var name = makeTileName(req);
+        var contentType = res.get('Content-Type');
+
         var headers = {
-          'Content-Length': body.length,
-          'Content-Type': res.get('Content-Type')
+          'Content-Length': body.length
         };
+
+        if (contentType && contentType !== '') {
+          headers['Content-Type'] = contentType;
+        }
+
         var buffer = new Buffer(body);
 
         handleS3Error = function handleS3Error(error) {

--- a/lib/cache/s3-cache.js
+++ b/lib/cache/s3-cache.js
@@ -93,14 +93,14 @@ module.exports = function setup(options) {
     });
   }
 
-  function checkModified(survey, tile, timestamp, done) {
+  function checkModified(survey, tile, timestamp) {
     var query = setupQuery(survey, tile, false, {
       'entries.modified': { $gt: new Date(timestamp) }
     });
     return check(query);
   }
 
-  function checkDeleted(survey, tile, timestamp, done) {
+  function checkDeleted(survey, tile, timestamp) {
     var query = setupQuery(survey, tile, true, {
       'entries.modified': { $gt: new Date(timestamp) }
     });

--- a/lib/controllers/features.js
+++ b/lib/controllers/features.js
@@ -140,7 +140,7 @@ exports.render = function render(req, res, next) {
   function handleData(error, data) {
     if (error) {
       console.log('Error generating tile', error);
-      res.send(500);
+      res.sendStatus(500);
       return;
     }
     res.send(data);
@@ -150,7 +150,7 @@ exports.render = function render(req, res, next) {
     layerId: layerId
   }).then(function (layerDef) {
     if (!layerDef) {
-      res.send(404);
+      res.sendStatus(404);
       return;
     }
 
@@ -163,7 +163,7 @@ exports.render = function render(req, res, next) {
   }).catch(function (error) {
     console.log('Error generating tile', error);
     console.log(error.stack);
-    res.send(500);
+    res.sendStatus(500);
   });
 };
 
@@ -210,7 +210,7 @@ exports.renderGrids = function renderGrids(req, res, next) {
   var handleData = function (error, data) {
     if (error) {
       console.log(error);
-      res.send(500);
+      res.sendStatus(500);
       return;
     }
     res.send(data);
@@ -221,7 +221,7 @@ exports.renderGrids = function renderGrids(req, res, next) {
     grid: true
   }).then(function (layerDef) {
     if (!layerDef) {
-      res.send(404);
+      res.sendStatus(404);
       return;
     }
 
@@ -251,6 +251,6 @@ exports.renderGrids = function renderGrids(req, res, next) {
   }).catch(function (error) {
     console.log('Error generating grid', error);
     console.log(error.stack);
-    res.send(500);
+    res.sendStatus(500);
   });
 };

--- a/lib/controllers/features.js
+++ b/lib/controllers/features.js
@@ -127,7 +127,7 @@ function smartBuffer(bounds, buffer) {
 /**
  * Render a tile using a map that we create or an existing cached map.
  */
-exports.render = function render(req, res, next) {
+exports.render = function render(req, res) {
   var tile = res.locals.tile;
   var layerId = req.params.layerId;
 
@@ -168,17 +168,17 @@ exports.render = function render(req, res, next) {
 };
 
 function selectFields(item, select) {
-    var ret = {};
-    Object.keys(item).forEach(function (field) {
-      if (field === 'object_id' || !!select[field]) {
-        if (typeof select[field] === 'object') {
-          ret[field] = selectFields(item[field], select[field]);
-        } else {
-          ret[field] = item[field];
-        }
+  var ret = {};
+  Object.keys(item).forEach(function (field) {
+    if (field === 'object_id' || !!select[field]) {
+      if (typeof select[field] === 'object') {
+        ret[field] = selectFields(item[field], select[field]);
+      } else {
+        ret[field] = item[field];
       }
-    });
-    return ret;
+    }
+  });
+  return ret;
 }
 
 function stripGridFields(grid, select) {
@@ -196,7 +196,7 @@ function stripGridFields(grid, select) {
 // TODO: Support grids for features
 // TODO: handle the routing/http stuff ourselves and just use nodetiles as a
 // renderer, like with the PNG tiles
-exports.renderGrids = function renderGrids(req, res, next) {
+exports.renderGrids = function renderGrids(req, res) {
   var format = req.params.format;
   var tile = res.locals.tile;
   var layerId = req.params.layerId;

--- a/lib/controllers/tile-json.js
+++ b/lib/controllers/tile-json.js
@@ -127,7 +127,7 @@ exports.get = function get(req, res, next) {
     } catch (e) {
       console.log(e);
       console.log(e.stack);
-      res.send(400);
+      res.sendStatus(400);
       return;
     }
 
@@ -151,7 +151,7 @@ exports.get = function get(req, res, next) {
     }).catch(function (error) {
       console.log(error);
       console.log(error.stack);
-      res.send(500);
+      res.sendStatus(500);
     });
   } else {
     // No layer definition, so we fall back to the legacy URLs
@@ -195,14 +195,14 @@ exports.getLayerDef = function getLayerDef(req, res) {
     layerId: req.params.layerId
   }).then(function (data) {
     if (!data) {
-      res.send(404);
+      res.sendStatus(404);
       return;
     }
     res.json(200, data);
   }).catch(function (error) {
     console.log(error);
     console.log(error.stack);
-    res.send(500);
+    res.sendStatus(500);
   });
 };
 

--- a/lib/controllers/tile-json.js
+++ b/lib/controllers/tile-json.js
@@ -114,7 +114,7 @@ function generateTileJSON(options) {
   return tilejson;
 }
 
-exports.get = function get(req, res, next) {
+exports.get = function get(req, res) {
   delete req.query._; // don't pass on jsonp function names
 
   var surveyId = req.params.surveyId;
@@ -207,7 +207,7 @@ exports.getLayerDef = function getLayerDef(req, res) {
 };
 
 
-exports.getFilteredKey = function getFilteredKey(req, res, next) {
+exports.getFilteredKey = function getFilteredKey(req, res) {
   delete req.query._; // don't pass on jsonp function names
 
   var key = req.params.key;
@@ -220,7 +220,7 @@ exports.getFilteredKey = function getFilteredKey(req, res, next) {
   res.jsonp(tileJson);
 };
 
-exports.getFilteredKeyValue = function getFilteredKey(req, res, next) {
+exports.getFilteredKeyValue = function getFilteredKey(req, res) {
   delete req.query._; // don't pass on jsonp function names
 
   var filterPath = 'filter/' + req.params.key + '/' + req.params.val;

--- a/lib/controllers/tiles.js
+++ b/lib/controllers/tiles.js
@@ -221,7 +221,7 @@ function smartBuffer(bounds, buffer) {
 /**
  * Render a tile using a map that we create or an existing cached map.
  */
-exports.render = function render(req, res, next) {
+exports.render = function render(req, res) {
   var key = req.params.key;
   var val = req.params.val;
   var surveyId = req.params.surveyId;
@@ -291,7 +291,7 @@ exports.render = function render(req, res, next) {
 
 // TODO: handle the routing/http stuff ourselves and just use nodetiles as a
 // renderer, like with the PNG tiles
-exports.renderGrids = function renderGrids(req, res, next) {
+exports.renderGrids = function renderGrids(req, res) {
   var surveyId = req.params.surveyId;
   var key = req.params.key;
   var val = req.params.val;

--- a/lib/controllers/tiles.js
+++ b/lib/controllers/tiles.js
@@ -258,7 +258,7 @@ exports.render = function render(req, res, next) {
   function handleData(error, data) {
     if (error) {
       console.log('Error generating tile', error);
-      res.send(500);
+      res.sendStatus(500);
       return;
     }
     res.send(data);
@@ -272,7 +272,7 @@ exports.render = function render(req, res, next) {
     surveyId: surveyId
   }).then(function (layerDef) {
     if (!layerDef) {
-      res.send(404);
+      res.sendStatus(404);
       return;
     }
 
@@ -285,7 +285,7 @@ exports.render = function render(req, res, next) {
   }).catch(function (error) {
     console.log('Error generating tile', error);
     console.log(error.stack);
-    res.send(500);
+    res.sendStatus(500);
   });
 };
 
@@ -325,7 +325,7 @@ exports.renderGrids = function renderGrids(req, res, next) {
   var handleData = function (error, data) {
     if (error) {
       console.log(error);
-      res.send(500);
+      res.sendStatus(500);
       return;
     }
     res.send(data);
@@ -340,7 +340,7 @@ exports.renderGrids = function renderGrids(req, res, next) {
     surveyId: surveyId
   }).then(function (layerDef) {
     if (!layerDef) {
-      res.send(404);
+      res.sendStatus(404);
       return;
     }
 
@@ -370,6 +370,6 @@ exports.renderGrids = function renderGrids(req, res, next) {
   }).catch(function (error) {
     console.log('Error generating grid', error);
     console.log(error.stack);
-    res.send(500);
+    res.sendStatus(500);
   });
 };

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -62,7 +62,7 @@ function parseTileName(req, res, next) {
 
   if (isNaN(tile[0]) || isNaN(tile[1]) || isNaN(tile[2])) {
     console.log('Error parsing tile URL params: ' + JSON.stringify(req.params));
-    res.send(400, 'Error parsing tile URL');
+    res.status(400).send('Error parsing tile URL');
     return;
   }
 

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -74,7 +74,7 @@ function parseTileName(req, res, next) {
 
 // If a requested tile is zoomed far out, respond with a transparent png
 function respondWithBlankTile(req, res, next) {
-  if(res.locals.tile[0] < settings.maxFeatureZoom) {
+  if (res.locals.tile[0] < settings.maxFeatureZoom) {
     res.setHeader('content-type', 'image/png');
     res.send(util.blankPNG256Buffer);
     return;

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lru-cache": "2.3.0",
     "mongoose": "~4.1.12",
     "morgan": "^1.6.1",
-    "newrelic": "~1.22.2",
+    "newrelic": "~1.23.0",
     "nodetiles-core": "LocalData/nodetiles-core#4e661e1c8140a48860d127339c5fd14b7ed86249",
     "pg": "~4.3.0",
     "pg-query-stream": "~0.7.0",


### PR DESCRIPTION
Express 4.x has deprecated the use of `res.send(statusCode, body)`.

In case the content type of a response hasn't been set, we should not try to pass it along to S3-cached data.